### PR TITLE
upgrade jquery.console.js to most recent version - fixes issue #2

### DIFF
--- a/resources/public/javascript/jquery.console.js
+++ b/resources/public/javascript/jquery.console.js
@@ -285,7 +285,7 @@
                 return false;
             }
           // // C-v: don't insert on paste event
-            if (e.ctrlKey && String.fromCharCode(keyCode).toLowerCase() == 'v') {
+            if ((e.ctrlKey || e.metaKey) && String.fromCharCode(keyCode).toLowerCase() == 'v') {
               return true;
             }
             if (acceptInput && cancelKeyPress != keyCode && keyCode >= 32){
@@ -409,7 +409,12 @@
 
         // Scroll to the bottom of the view
         function scrollToBottom() {
-            inner.attr({ scrollTop: inner.attr("scrollHeight") });;
+            if (jQuery.fn.jquery > "1.6") {
+                inner.prop({ scrollTop: inner.prop("scrollHeight") });
+            }
+            else {
+                inner.attr({ scrollTop: inner.attr("scrollHeight") });
+            }
         };
 
 	function cancelExecution() {


### PR DESCRIPTION
The issue was with jquery.console.js' handling of the metaKey on OSX. This pull request just upgrades to the most recent version. 

More information can be found here - https://github.com/chrisdone/jquery-console/pull/18
