### PR TITLE
Fixes for a few synonym examples

### DIFF
--- a/resources/public/synonym.html
+++ b/resources/public/synonym.html
@@ -756,8 +756,8 @@ invalidEmail.match(/@/g)
             <div class="cheat-box">
                             <pre>
 (def invalid-email "f@il@example.com")
-(.match email #"(?g)@")
-;; => ["@", "@"]
+(re-seq #"@" invalid-email)
+;; => ("@" "@")
 </pre>
             </div>
         </div>


### PR DESCRIPTION
A few small fixes for some of the synonym examples. AFAICT, ClojureScript regex's don't support the `g` modifier, so we need to use `re-seq`.
