### PR TITLE
Fixed a small typo in your excellent synonym doc.

### DIFF
--- a/resources/public/synonym.html
+++ b/resources/public/synonym.html
@@ -512,7 +512,7 @@ b["bar"] = 1; // destructive update
               :city "Bit City"
               :zip 10111011})
 
-(map address [:zip street])
+(map address [:zip :street])
 ;; => (10111011 "1 Bit Ave.")
 ;; Collections can act as
 ;; functions. HashMaps are functions


### PR DESCRIPTION
Callable collections: Map keyword 'street' had accidental colectomy.
