### PR TITLE
Remove an extra ? in synonym.

### DIFF
--- a/resources/public/synonym.html
+++ b/resources/public/synonym.html
@@ -597,7 +597,7 @@ if (bugNumbers.length > 0) {
                             <pre class="brush: clojure">
 (def bug-numbers [3234 452 944 124])
 
-(if (pos? (count bug-numbers?))
+(if (pos? (count bug-numbers))
   (println "Not ready for release"))</pre>
             </div>
         </div>


### PR DESCRIPTION
Currently synonym has this example:

```
(def bug-numbers [3234 452 944 124])
(if (pos? (count bug-numbers?))
  (println "Not ready for release"))
```

...which I believe the `?` after `bug-number?` is a mistake.  This patch remove the extra `?` at the end.
