### PR TITLE
add link from index.html to synonym.html

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -40,7 +40,7 @@ remove this notice, or any other, from this software.
     
     <div class="rule sixteen columns"></div>
 
-    <h3>ClojureScript at a glance - <a href="https://github.com/fogus/clojure-cheatsheets/blob/master/pdf/cljs-cheatsheet.pdf?raw=true" class="doc-link">PDF</a> | <a href="http://clojuredocs.org/" class="doc-link">Searchable docs</a></h3>
+    <h3>ClojureScript at a glance - <a href="https://github.com/fogus/clojure-cheatsheets/blob/master/pdf/cljs-cheatsheet.pdf?raw=true" class="doc-link">PDF</a> | <a href="http://clojuredocs.org/" class="doc-link">Searchable docs</a> | <a href="synonym.html" class="doc-link">Translations from JavaScript</a></h3>
     
     <div class="cheat-box-container eight columns">
       <div class="cheat-box">


### PR DESCRIPTION
It would be nice if index.html linked to the quite helpful "synonym" page. The idea was floated in `#clojure` on Freenode and @swannodette suggested submitting the page change as a pull request.
