### PR TITLE
Turn *read-eval* off

### DIFF
--- a/src/clj/himera/server/service.clj
+++ b/src/clj/himera/server/service.clj
@@ -53,7 +53,7 @@
   (fn [req]
     (if-let [body (and (clj-request? req) (:body req))]
       (let [bstr (slurp body)
-            clj-params (binding [*read-eval* false]
+            clj-params (binding [reader/*read-eval* false]
                          (reader/read-string {:read-cond :allow :features #{:cljs}} bstr))
             req* (assoc req
                    :clj-params clj-params


### PR DESCRIPTION
If you go to https://himera.herokuapp.com/index.html and input `#=(+ 1 2)` then it gives `3`.

Looks like using tools.reader requires binding it's `*read-eval*` instead of clojure's.
