### PR TITLE
Upgrade clj and cljs deps

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,13 +8,13 @@
 
 (defproject himera "0.1.0-SNAPSHOT"
   :description "ClojureScript compiler service."
-  :dependencies [[org.clojure/clojure "1.7.0-master-SNAPSHOT"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.reader "0.9.1"]
                  [ring "1.3.2"]
                  [compojure "1.3.3"]
                  [domina "1.0.3"]
-                 [org.clojure/clojurescript "0.0-3211"]]
-  :plugins [[lein-cljsbuild "1.0.5"]]
+                 [org.clojure/clojurescript "1.7.228"]]
+  :plugins [[lein-cljsbuild "1.1.2"]]
   :dev-dependencies [[jline "0.9.94"]
                      [lein-marginalia "0.7.0-SNAPSHOT"]]
   :cljsbuild {:builds


### PR DESCRIPTION
Generates this error:

```
Caused by:
java.lang.ClassCastException: clojure.core$fn cannot be cast to java.util.concurrent.Future
    at clojure.core$deref_future.invokeStatic(core.clj:2206)
    at clojure.core$deref.invokeStatic(core.clj:2228)
    at clojure.core$deref.invoke(core.clj:2214)
    at cljs.analyzer$macroexpand_1_STAR_$fn__3794.invoke(analyzer.cljc:2357)
    at cljs.analyzer$macroexpand_1_STAR_.invokeStatic(analyzer.cljc:2356)
    at cljs.analyzer$macroexpand_1_STAR_.invoke(analyzer.cljc:2347)
    at cljs.analyzer$macroexpand_1.invokeStatic(analyzer.cljc:2404)
    at cljs.analyzer$macroexpand_1.invoke(analyzer.cljc:2400)
    at cljs.analyzer$analyze_seq.invokeStatic(analyzer.cljc:2434)
    at cljs.analyzer$analyze_seq.invoke(analyzer.cljc:2417)
    at cljs.analyzer$analyze_form.invokeStatic(analyzer.cljc:2549)
    at cljs.analyzer$analyze_form.invoke(analyzer.cljc:2545)
    at cljs.analyzer$analyze_STAR_.invokeStatic(analyzer.cljc:2596)
    at cljs.analyzer$analyze_STAR_.invoke(analyzer.cljc:2587)
    at cljs.analyzer$analyze.invokeStatic(analyzer.cljc:2612)
    at cljs.analyzer$analyze.invoke(analyzer.cljc:2599)
    at cljs.analyzer$analyze.invokeStatic(analyzer.cljc:2607)
    at cljs.analyzer$analyze.invoke(analyzer.cljc:2599)
    at cljs.analyzer$analyze.invokeStatic(analyzer.cljc:2606)
    at cljs.analyzer$analyze.invoke(analyzer.cljc:2599)
    at cljs.analyzer$parse_invoke_STAR_$ana_expr__3769.invoke(analyzer.cljc:2252)
    at clojure.core$map$fn__4785.invoke(core.clj:2646)
    at clojure.lang.LazySeq.sval(LazySeq.java:40)
    at clojure.lang.LazySeq.seq(LazySeq.java:49)
    at clojure.lang.RT.seq(RT.java:521)
    at clojure.lang.LazilyPersistentVector.create(LazilyPersistentVector.java:44)
    at clojure.core$vec.invokeStatic(core.clj:377)
    at clojure.core$vec.invoke(core.clj:367)
    at cljs.analyzer$parse_invoke_STAR_.invokeStatic(analyzer.cljc:2259)
    at cljs.analyzer$parse_invoke_STAR_.invoke(analyzer.cljc:2230)
    at cljs.analyzer$parse_invoke.invokeStatic(analyzer.cljc:2268)
    at cljs.analyzer$parse_invoke.invoke(analyzer.cljc:2266)
    at cljs.analyzer$analyze_seq_STAR_.invokeStatic(analyzer.cljc:2411)
    at cljs.analyzer$analyze_seq_STAR_.invoke(analyzer.cljc:2408)
    at cljs.analyzer$analyze_seq_STAR__wrap.invokeStatic(analyzer.cljc:2415)
    at cljs.analyzer$analyze_seq_STAR__wrap.invoke(analyzer.cljc:2413)
    at cljs.analyzer$analyze_seq.invokeStatic(analyzer.cljc:2436)
    at cljs.analyzer$analyze_seq.invoke(analyzer.cljc:2417)
    at cljs.analyzer$analyze_form.invokeStatic(analyzer.cljc:2549)
    at cljs.analyzer$analyze_form.invoke(analyzer.cljc:2545)
    at cljs.analyzer$analyze_STAR_.invokeStatic(analyzer.cljc:2596)
    at cljs.analyzer$analyze_STAR_.invoke(analyzer.cljc:2587)
    at cljs.analyzer$analyze.invokeStatic(analyzer.cljc:2612)
    at cljs.analyzer$analyze.invoke(analyzer.cljc:2599)
    at cljs.analyzer$analyze.invokeStatic(analyzer.cljc:2607)
    at cljs.analyzer$analyze.invoke(analyzer.cljc:2599)
    at cljs.analyzer$analyze.invokeStatic(analyzer.cljc:2606)
    at cljs.analyzer$analyze.invoke(analyzer.cljc:2599)
    at himera.server.cljs$fn__5213.invokeStatic(cljs.clj:30)
    at himera.server.cljs$fn__5213.invoke(cljs.clj:29)
    at himera.server.cljs$build$fn__5206$fn__5207.invoke(cljs.clj:26)
```

If you try to execute:

```
 (map (fn [n] (* n n n)) [1 2 3 4])
```

Not sure why.
